### PR TITLE
tests: add define for manipulating task priorities

### DIFF
--- a/include/porting_layer.h
+++ b/include/porting_layer.h
@@ -75,6 +75,7 @@
 	TYPE max_cycles = NO_INIT_MIN_TIME_VALUE; \
 	TYPE min_cycles = NO_INIT_MAX_TIME_VALUE; \
 	TYPE average_cycles = NO_INIT_MIN_TIME_VALUE; \
+	unsigned num_measurements = 0; \
 
 #else
 
@@ -91,7 +92,7 @@
 	SUFFIX##_t2 = no_time_get();
 
 #ifndef NO_VERBOSE_RESULTS
-#define COMPUTE_TIME_STATS(SUFFIX, n) do { \
+#define COMPUTE_TIME_STATS(SUFFIX, i) do { \
 			cycles = no_time_diff(&SUFFIX##_t1, &SUFFIX##_t2); \
 			if (cycles < NO_PART_MAX_GAP) { \
 				if (cycles > max_cycles) \
@@ -102,13 +103,15 @@
 				{ \
 					min_cycles = cycles; \
 				} \
-				average_cycles += (cycles - average_cycles) / (n + 1); \
+				average_cycles += (cycles - average_cycles) / (num_measurements + 1); \
+				num_measurements++; \
 			}\
 		} while(0);
 #else
-#define COMPUTE_TIME_STATS(SUFFIX, n) do { \
+#define COMPUTE_TIME_STATS(SUFFIX, i) do { \
 			cycles = no_time_diff(&SUFFIX##_t1, &SUFFIX##_t2); \
-			no_cycles_results[n] = cycles; \
+			no_cycles_results[i] = cycles; \
+			num_measurements++; \
 		} while(0);
 #endif // NO_VERBOSE_RESULTS
 
@@ -116,7 +119,9 @@
 #define RESET_TIME_STATS() \
 	average_cycles = 0; \
 	max_cycles = 0; \
-	min_cycles = NO_INIT_MAX_TIME_VALUE;
+	min_cycles = NO_INIT_MAX_TIME_VALUE; \
+	num_measurements = 0; \
+
 #else
 #define RESET_TIME_STATS()
 #endif // NO_VERBOSE_RESULTS
@@ -151,7 +156,7 @@
 #define WRITE_T2_COUNTER(SUFFIX) \
 	no_tracing_write_event(SUFFIX##_ev_id_end);
 
-#define COMPUTE_TIME_STATS(SUFFIX, N) \
+#define COMPUTE_TIME_STATS(SUFFIX, i) \
 
 #define RESET_TIME_STATS() \
 

--- a/include/porting_layer.h
+++ b/include/porting_layer.h
@@ -164,6 +164,10 @@
 
 #endif // TRACING
 
+#ifndef NO_DECREASE_TASK_PRIO
+#define NO_DECREASE_TASK_PRIO(prio, decrease_by) (prio - decrease_by)
+#endif // NO_DECREASE_TASK_PRIO
+
 /**
  * Porting API
  */

--- a/include/porting_layer.h
+++ b/include/porting_layer.h
@@ -111,7 +111,6 @@
 #define COMPUTE_TIME_STATS(SUFFIX, i) do { \
 			cycles = no_time_diff(&SUFFIX##_t1, &SUFFIX##_t2); \
 			no_cycles_results[i] = cycles; \
-			num_measurements++; \
 		} while(0);
 #endif // NO_VERBOSE_RESULTS
 

--- a/tests/mq/mq.c
+++ b/tests/mq/mq.c
@@ -37,7 +37,7 @@ no_task_retval_t mq_initialize_test(no_task_argument_t args)
 
 	tasks_handle[0] = no_create_task(sender,
 			"S",
-			BASE_PRIO - 1 /* sender is the low priority task. */
+			NO_DECREASE_TASK_PRIO(BASE_PRIO, 1) /* sender is the low priority task. */
 		);
 
 	tasks_handle[1] = no_create_task(receiver,

--- a/tests/mq/mq_workload.c
+++ b/tests/mq/mq_workload.c
@@ -50,7 +50,7 @@ no_task_retval_t mq_initialize_test(no_task_argument_t args)
 
 	tasks_handle[0] = no_create_task(sender,
 			"S",
-			BASE_PRIO - 1 /* sender is the low priority task. */
+			NO_DECREASE_TASK_PRIO(BASE_PRIO, 1) /* sender is the low priority task. */
 		);
 
 	tasks_handle[1] = no_create_task(receiver,

--- a/tests/mutex/mutex.c
+++ b/tests/mutex/mutex.c
@@ -38,7 +38,7 @@ no_task_retval_t mutex_initialize_test(no_task_argument_t args)
 
 	tasks_handle[0] = no_create_task(sender,
 			"S",
-			BASE_PRIO - 1 /* sender is the low priority task. */
+			NO_DECREASE_TASK_PRIO(BASE_PRIO, 1) /* sender is the low priority task. */
 		);
 
 	tasks_handle[1] = no_create_task(receiver,

--- a/tests/mutex/mutex_pip.c
+++ b/tests/mutex/mutex_pip.c
@@ -44,12 +44,12 @@ no_task_retval_t mutex_processing_initialize_tests(no_task_argument_t args)
 	/* Create task */
 	tasks_handle[0] = no_create_task(TC_low_prio,
 			"L",
-			BASE_PRIO - 2 /* TC_low_prio is the low priority task. */
+			NO_DECREASE_TASK_PRIO(BASE_PRIO, 2) /* TC_low_prio is the low priority task. */
 		);
 
 	tasks_handle[1] = no_create_task(TB_med_prio,
 			"M",
-			BASE_PRIO - 1 /* TB_med_prio is the med priority task. */
+			NO_DECREASE_TASK_PRIO(BASE_PRIO, 1) /* TB_med_prio is the med priority task. */
 		);
 
 	tasks_handle[2] = no_create_task(TA_high_prio,

--- a/tests/mutex/mutex_processing.c
+++ b/tests/mutex/mutex_processing.c
@@ -34,7 +34,7 @@ no_task_retval_t mutex_processing_initialize_tests(no_task_argument_t args)
 	/* Create task */
 	task_handle = no_create_task(task,
 			"S",
-			BASE_PRIO - 1 /* `task` is the only task */
+			NO_DECREASE_TASK_PRIO(BASE_PRIO, 1) /* `task` is the only task */
 		);
 
 	return TASK_DEFAULT_RETURN;

--- a/tests/mutex/mutex_workload.c
+++ b/tests/mutex/mutex_workload.c
@@ -51,7 +51,7 @@ no_task_retval_t mutex_initialize_test(no_task_argument_t args)
 
 	tasks_handle[0] = no_create_task(sender,
 			"S",
-			BASE_PRIO - 1 /* sender is the low priority task. */
+			NO_DECREASE_TASK_PRIO(BASE_PRIO, 1) /* sender is the low priority task. */
 		);
 
 	tasks_handle[1] = no_create_task(receiver,

--- a/tests/partition/jitter.c
+++ b/tests/partition/jitter.c
@@ -43,7 +43,7 @@ no_task_retval_t jitter_initialize_test(no_task_argument_t args)
 		tasks_name[i][2] = (66 + i) % 255;
 		tasks_name[i][3] = (67 + i) % 255;
 		tasks_name[i][4] = '\0';
-		tasks_handle[i] = no_create_task(task, tasks_name[i], BASE_PRIO - 1);
+		tasks_handle[i] = no_create_task(task, tasks_name[i], NO_DECREASE_TASK_PRIO(BASE_PRIO, 1));
 	}
 
 	tasks_handle[NB_TASK + 1] = no_create_task(monitor, "MON", BASE_PRIO);

--- a/tests/semaphore/sem.c
+++ b/tests/semaphore/sem.c
@@ -36,7 +36,7 @@ no_task_retval_t sem_initialize_test(no_task_argument_t args)
 
 	tasks_handle[0] = no_create_task(sender,
 			"S",
-			BASE_PRIO - 1 /* sender is the low priority task. */
+			NO_DECREASE_TASK_PRIO(BASE_PRIO, 1) /* sender is the low priority task. */
 		);
 
 	tasks_handle[1] = no_create_task(receiver,

--- a/tests/semaphore/sem_prio.c
+++ b/tests/semaphore/sem_prio.c
@@ -46,7 +46,7 @@ no_task_retval_t sem_prio_initialize_test(no_task_argument_t args)
 
 	tasks_handle[0] = no_create_task(TC_low_prio,
 			"L",
-			BASE_PRIO - 2 /* TC_low_prio is the low priority task. */
+			NO_DECREASE_TASK_PRIO(BASE_PRIO, 2) /* TC_low_prio is the low priority task. */
 		);
 
 	for (i = 0; i < NB_TASK; i++)

--- a/tests/semaphore/sem_processing.c
+++ b/tests/semaphore/sem_processing.c
@@ -32,7 +32,7 @@ no_task_retval_t sem_processing_initialize_test(no_task_argument_t args)
 
 	task_handle = no_create_task(task,
 			"S",
-			BASE_PRIO - 1 /* `task` is the only task */
+			NO_DECREASE_TASK_PRIO(BASE_PRIO, 1) /* `task` is the only task */
 		);
 
 	return TASK_DEFAULT_RETURN;

--- a/tests/semaphore/sem_workload.c
+++ b/tests/semaphore/sem_workload.c
@@ -49,7 +49,7 @@ no_task_retval_t sem_initialize_test(no_task_argument_t args)
 
 	tasks_handle[0] = no_create_task(sender,
 			"S",
-			BASE_PRIO - 1 /* sender is the low priority task. */
+			NO_DECREASE_TASK_PRIO(BASE_PRIO, 1) /* sender is the low priority task. */
 		);
 
 	tasks_handle[1] = no_create_task(receiver,


### PR DESCRIPTION
If a test requires threads of different priority, it currently assumes
that using (BASE_PRIO - x) yields a lower thread priority. There exist
RTOSes (e.g. Zephyr) where the priority function is inversed, i.e. a
smaller number means higher priority. This breaks tests that use thread
priorities, leading to invalid measurements.

Add a new function-like define "NO_DECREASE_TASK_PRIO" that reduces
a given task priority by a certain amount. This allows the porting layer to
redefine the function if necessary while not breaking the existing examples.