### PR TITLE
Fix UB caused by uninitialized variable i

### DIFF
--- a/tests/mq/mq_workload.c
+++ b/tests/mq/mq_workload.c
@@ -58,7 +58,7 @@ no_task_retval_t mq_initialize_test(no_task_argument_t args)
 			BASE_PRIO /* receiver is the high priority task. */
 		);
 
-	for (i < 0 ; i < NB_WORKLOAD_TASK; i++)
+	for (i = 0 ; i < NB_WORKLOAD_TASK; i++)
 	{
 		workload_tasks_name[i][0] = 65;
 		workload_tasks_name[i][1] = (65 + i) % 255;
@@ -113,7 +113,7 @@ no_task_retval_t receiver(no_task_argument_t args)
 
 no_task_retval_t workload_task(no_task_argument_t args)
 {
-	int32_t i;
+	int32_t i = 0;
 	unsigned long _workload_results[100];
 
 	while (1)

--- a/tests/mutex/mutex_workload.c
+++ b/tests/mutex/mutex_workload.c
@@ -59,7 +59,7 @@ no_task_retval_t mutex_initialize_test(no_task_argument_t args)
 			BASE_PRIO /* receiver is the high priority task. */
 		);
 
-	for (i < 0 ; i < NB_WORKLOAD_TASK; i++)
+	for (i = 0 ; i < NB_WORKLOAD_TASK; i++)
 	{
 		workload_tasks_name[i][0] = 65;
 		workload_tasks_name[i][1] = (65 + i) % 255;
@@ -118,7 +118,7 @@ no_task_retval_t receiver(no_task_argument_t args)
 
 no_task_retval_t workload_task(no_task_argument_t args)
 {
-	int32_t i;
+	int32_t i = 0;
 	int32_t j;
 	unsigned long _workload_results[100];
 

--- a/tests/semaphore/sem_workload.c
+++ b/tests/semaphore/sem_workload.c
@@ -57,7 +57,7 @@ no_task_retval_t sem_initialize_test(no_task_argument_t args)
 			BASE_PRIO /* receiver is the high priority task. */
 		);
 
-	for (i < 0 ; i < NB_WORKLOAD_TASK; i++)
+	for (i = 0 ; i < NB_WORKLOAD_TASK; i++)
 	{
 		workload_tasks_name[i][0] = 65;
 		workload_tasks_name[i][1] = (65 + i) % 255;
@@ -111,7 +111,7 @@ no_task_retval_t receiver(no_task_argument_t args)
 
 no_task_retval_t workload_task(no_task_argument_t args)
 {
-	int32_t i;
+	int32_t i = 0;
 	unsigned long _workload_results[100];
 
 	while (1)


### PR DESCRIPTION
Example output of clang:
```
RTOSBench/tests/mq/mq_workload.c:61:9: warning: relational comparison result unused [-Wunused-comparison]
   61 |         for (i < 0 ; i < NB_WORKLOAD_TASK; i++)
      |              ~~^~~
RTOSBench/tests/mq/mq_workload.c:61:7: warning: variable 'i' is uninitialized when used here [-Wuninitialized]
   61 |         for (i < 0 ; i < NB_WORKLOAD_TASK; i++)
      |              ^
RTOSBench/tests/mq/mq_workload.c:46:11: note: initialize the variable 'i' to silence this warning
   46 |         int32_t i;
      |                  ^
      |                   = 0
RTOSBench/tests/mq/mq_workload.c:123:3: warning: variable 'i' is uninitialized when used here [-Wuninitialized]
  123 |                 i++;
      |                 ^
RTOSBench/tests/mq/mq_workload.c:116:11: note: initialize the variable 'i' to silence this warning
  116 |         int32_t i;
      |                  ^
      |                   = 0
4 warnings generated.
```
As a consequence, Clang removes the entire loop, and the tests have no workload tasks.