### PR TITLE
Avoid optimizing workload away

### DIFF
--- a/tests/mq/mq_workload.c
+++ b/tests/mq/mq_workload.c
@@ -114,7 +114,7 @@ no_task_retval_t receiver(no_task_argument_t args)
 no_task_retval_t workload_task(no_task_argument_t args)
 {
 	int32_t i;
-	unsigned long _workload_results[100];
+	volatile unsigned long _workload_results[100];
 
 	while (1)
 	{

--- a/tests/mutex/mutex_workload.c
+++ b/tests/mutex/mutex_workload.c
@@ -120,7 +120,7 @@ no_task_retval_t workload_task(no_task_argument_t args)
 {
 	int32_t i;
 	int32_t j;
-	unsigned long _workload_results[100];
+	volatile unsigned long _workload_results[100];
 
 	while (1)
 	{

--- a/tests/semaphore/sem_processing.c
+++ b/tests/semaphore/sem_processing.c
@@ -44,7 +44,7 @@ no_task_retval_t task(no_task_argument_t args)
 	DECLARE_TIME_COUNTERS(no_time_t, inc);
 	DECLARE_TIME_COUNTERS(no_time_t, dec);
 	DECLARE_TIME_STATS(int64_t);
-	unsigned long _workload_results[NB_ITER];
+	volatile unsigned long _workload_results[NB_ITER];
 
 	/* 1b - Measure semaphore signaling time */
 	for (i = 0; i < NB_ITER; i++)

--- a/tests/semaphore/sem_workload.c
+++ b/tests/semaphore/sem_workload.c
@@ -112,7 +112,7 @@ no_task_retval_t receiver(no_task_argument_t args)
 no_task_retval_t workload_task(no_task_argument_t args)
 {
 	int32_t i;
-	unsigned long _workload_results[100];
+	volatile unsigned long _workload_results[100];
 
 	while (1)
 	{


### PR DESCRIPTION
Clang without volatile:
```
8000111c <workload_task>:
8000111c: ff010113         addi    sp, sp, -0x10
80001120: 00112623         sw    ra, 0xc(sp)
80001124: 060000ef         jal    0x80001184 <no_task_yield>
80001128: ffdff06f         j    0x80001124 <workload_task+0x8>
```
With volatile:
```
8000111c <workload_task>:
8000111c: e5010113         addi    sp, sp, -0x1b0
80001120: 1a112623         sw    ra, 0x1ac(sp)
80001124: 1a812423         sw    s0, 0x1a8(sp)
80001128: 1a912223         sw    s1, 0x1a4(sp)
8000112c: 1b212023         sw    s2, 0x1a0(sp)
80001130: 19312e23         sw    s3, 0x19c(sp)
80001134: 19412c23         sw    s4, 0x198(sp)
80001138: 00000413         li    s0, 0x0
8000113c: 00810493         addi    s1, sp, 0x8
80001140: 51eb8537         lui    a0, 0x51eb8
80001144: e7000913         li    s2, -0x190
80001148: 51f50993         addi    s3, a0, 0x51f
8000114c: 00030a37         lui    s4, 0x30
80001150: 03343533         mulhu    a0, s0, s3
80001154: 00555513         srli    a0, a0, 0x5
80001158: 03250533         mul    a0, a0, s2
8000115c: 00a48533         add    a0, s1, a0
80001160: 01452023         sw    s4, 0x0(a0)
80001164: 068000ef         jal    0x800011cc <no_task_yield>
80001168: 00140413         addi    s0, s0, 0x1
8000116c: 00448493         addi    s1, s1, 0x4
80001170: fe1ff06f         j    0x80001150 <workload_task+0x34>
```